### PR TITLE
CS-11702-Fix-incorrect-test-reporting-to-Slack: edit results-parser to check for errors too

### DIFF
--- a/app/results-parser.ts
+++ b/app/results-parser.ts
@@ -61,7 +61,7 @@ export default class ResultsParser {
   }
 
   private getTestStatus(testJson) {
-    if(testJson["failure"] !== undefined){
+    if(testJson["failure"] !== undefined || testJson["error"] !== undefined){
       return "failed";
     }
     else if(testJson["skipped"] !== undefined){


### PR DESCRIPTION
JUnit XML uses both <failure> and <error> child elements to represent unsuccessful tests — <failure> for assertion failures and <error> for unexpected errors (e.g. infrastructure issues, uncaught exceptions).

The parser only checked for <failure>, so any testcase with an <error> element was silently counted as passed. This caused the Slack report to show inflated pass counts and miss failed tests entirely.

Fix: extend getTestStatus to treat <error> the same as <failure>.